### PR TITLE
fix: 移除书单页对无帖子书单的封面请求

### DIFF
--- a/src/pages/BooklistsPage/index.tsx
+++ b/src/pages/BooklistsPage/index.tsx
@@ -97,7 +97,7 @@ export function BooklistsPage() {
         return data.results?.[0]?.thumbnail_urls?.[0] || null;
       },
       staleTime: 5 * 60 * 1000,
-      enabled: !booklist.cover_image_url,
+      enabled: !booklist.cover_image_url && booklist.item_count > 0,
     })),
   });
 


### PR DESCRIPTION
对于 item_count = 0 的书单，即使请求书单内帖子详情，也无法获取到封面