### PR TITLE
fix: 书单封面修复

### DIFF
--- a/src/pages/BooklistsPage/index.tsx
+++ b/src/pages/BooklistsPage/index.tsx
@@ -7,7 +7,6 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { useQueries } from "@tanstack/react-query";
 import { Select } from "@/shared/ui/Select";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -23,7 +22,6 @@ import {
 import { BooklistFormModal } from "@/features/booklists/components/BooklistFormModal";
 import { FluidDivider } from "@/shared/ui/FluidDivider";
 import { AnimatedPagination } from "@/shared/ui/AnimatedPagination";
-import { booklistsApi } from "@/features/booklists/api/booklistsApi";
 import { useBooklistURLParams } from "@/features/booklists/hooks/useBooklistURLParams";
 
 type BooklistScope = "public" | "mine" | "collected";
@@ -88,26 +86,6 @@ export function BooklistsPage() {
     ],
     [scope],
   );
-
-  const latestCoverQueries = useQueries({
-    queries: normalizedResults.map((booklist) => ({
-      queryKey: ["booklists", "latest-cover", booklist.id],
-      queryFn: async () => {
-        const data = await booklistsApi.listItems(booklist.id, { offset: 0, limit: 1 });
-        return data.results?.[0]?.thumbnail_urls?.[0] || null;
-      },
-      staleTime: 5 * 60 * 1000,
-      enabled: !booklist.cover_image_url && booklist.item_count > 0,
-    })),
-  });
-
-  const fallbackCoverMap = useMemo(() => {
-    const map = new Map<number, string | null>();
-    normalizedResults.forEach((booklist, index) => {
-      map.set(booklist.id, latestCoverQueries[index]?.data || null);
-    });
-    return map;
-  }, [latestCoverQueries, normalizedResults]);
 
   return (
     <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 flex flex-col gap-10 p-4 sm:p-6 lg:gap-14 lg:p-8">
@@ -261,11 +239,7 @@ export function BooklistsPage() {
                   undefined
                 }
                 ownerAvatarUrl={booklist.author?.avatar_url ?? null}
-                coverImageUrl={
-                  booklist.cover_image_url ||
-                  fallbackCoverMap.get(booklist.id) ||
-                  null
-                }
+                coverImageUrl={booklist.cover_image_url || null}
                 onOpen={(id) => navigate(`/booklists/${id}`)}
                 onToggleCollect={(item) =>
                   collectMutation.mutate({

--- a/src/pages/MePage/MePreferencesSection.tsx
+++ b/src/pages/MePage/MePreferencesSection.tsx
@@ -114,7 +114,7 @@ export function MePreferencesSection({
 
             <label className="block space-y-2">
               <span className="block text-sm font-medium text-(--od-text-secondary)">
-                每页条数
+                BOT 每页条数
               </span>
               <input
                 type="number"

--- a/src/shared/lib/imageOptimization.ts
+++ b/src/shared/lib/imageOptimization.ts
@@ -13,7 +13,7 @@ const DISCORD_MEDIA_DOMAIN = 'media.discordapp.net';
  * 3. 强制请求 WebP 格式以平衡清晰度与体积
  */
 export function optimizeDiscordImageUrl(url: string, width: number = 800): string {
-  if (!url || !url.includes(DISCORD_CDN_DOMAIN)) {
+  if (!url || !url.includes(DISCORD_CDN_DOMAIN) || url.includes('/embed/')) {
     return url;
   }
 


### PR DESCRIPTION
1. 书单接口不返回封面的，不再请求详情以获取封面 
    仅无帖子书单会有这种情况，进行查询会额外耗费资源

2. DC 默认头像查询修复 
    media 域名不服务 /embed，因此跳过优化