### PR TITLE
代码审查整改与渲染性能优化

### DIFF
--- a/src/entities/thread/ThreadCard.tsx
+++ b/src/entities/thread/ThreadCard.tsx
@@ -30,6 +30,7 @@ interface ThreadCardProps {
   index?: number;
   hideBottomDivider?: boolean;
   masonry?: boolean;
+  animateIn?: boolean;
 }
 
 const thumbnailAspectRatioCache = new Map<string, number>();
@@ -44,6 +45,7 @@ function ThreadCardImpl({
   index = 0,
   hideBottomDivider = false,
   masonry = false,
+  animateIn = true,
 }: ThreadCardProps) {
   const ariaLabel = `帖子：${thread.title}。作者：${thread.author?.display_name || thread.author?.name || "未知"}。${thread.reply_count}条回复，${thread.reaction_count}个点赞。标签：${thread.tags.join(", ")}`;
 
@@ -123,6 +125,11 @@ function ThreadCardImpl({
         ? "aspect-5/7"
         : "aspect-3/4";
 
+  // 缓存命中直出的页面传 animateIn=false：内容用户已看过，不再重播浮现动画。
+  const entranceClass = animateIn
+    ? " animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both"
+    : "";
+
   return (
     <>
       <article
@@ -131,9 +138,9 @@ function ThreadCardImpl({
         aria-label={ariaLabel}
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        className={`group flex w-full cursor-pointer flex-col rounded-[1.45rem] [content-visibility:auto] [contain-intrinsic-size:auto_560px] animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both focus:outline-hidden focus-visible:ring-2 focus-visible:ring-(--od-accent) ${masonry ? "h-auto" : "h-full"}`}
+        className={`group flex w-full cursor-pointer flex-col rounded-[1.45rem] [content-visibility:auto] [contain-intrinsic-size:auto_560px]${entranceClass} focus:outline-hidden focus-visible:ring-2 focus-visible:ring-(--od-accent) ${masonry ? "h-auto" : "h-full"}`}
         style={{
-          animationDelay,
+          animationDelay: animateIn ? animationDelay : undefined,
           WebkitTapHighlightColor: "transparent",
         }}
         onMouseDown={(e) => {

--- a/src/entities/thread/ThreadCard.tsx
+++ b/src/entities/thread/ThreadCard.tsx
@@ -76,6 +76,7 @@ function ThreadCardImpl({
   const [naturalAspectRatio, setNaturalAspectRatio] = useState<number | null>(
     () => thumbnailAspectRatioCache.get(initialThumbnail) || null,
   );
+  const articleRef = useRef<HTMLElement>(null);
   const titleViewportRef = useRef<HTMLSpanElement>(null);
   const titleTrackRef = useRef<HTMLSpanElement>(null);
   const [titleShift, setTitleShift] = useState(0);
@@ -105,7 +106,14 @@ function ThreadCardImpl({
 
     updateTitleShift();
     window.addEventListener("resize", updateTitleShift);
-    return () => window.removeEventListener("resize", updateTitleShift);
+    // 卡片带 content-visibility:auto，屏外首挂时 layout 被跳过、scrollWidth
+    // 读到 0；等浏览器把它渲染出来时（进入视口）借这个事件补一次测量。
+    const article = articleRef.current;
+    article?.addEventListener("contentvisibilityautostatechange", updateTitleShift);
+    return () => {
+      window.removeEventListener("resize", updateTitleShift);
+      article?.removeEventListener("contentvisibilityautostatechange", updateTitleShift);
+    };
   }, [thread.title, fontSize, searchQuery]);
 
   const mediaAspectClass =
@@ -118,11 +126,12 @@ function ThreadCardImpl({
   return (
     <>
       <article
+        ref={articleRef}
         role="button"
         aria-label={ariaLabel}
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        className={`group flex w-full cursor-pointer flex-col rounded-[1.45rem] animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both focus:outline-hidden focus-visible:ring-2 focus-visible:ring-(--od-accent) ${masonry ? "h-auto" : "h-full"}`}
+        className={`group flex w-full cursor-pointer flex-col rounded-[1.45rem] [content-visibility:auto] [contain-intrinsic-size:auto_560px] animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both focus:outline-hidden focus-visible:ring-2 focus-visible:ring-(--od-accent) ${masonry ? "h-auto" : "h-full"}`}
         style={{
           animationDelay,
           WebkitTapHighlightColor: "transparent",

--- a/src/entities/thread/ThreadListItem.tsx
+++ b/src/entities/thread/ThreadListItem.tsx
@@ -25,6 +25,7 @@ interface ThreadListItemProps {
   onPreview?: (thread: Thread) => void;
   booklistComment?: string | null;
   index?: number;
+  animateIn?: boolean;
 }
 
 function ThreadListItemImpl({
@@ -35,6 +36,7 @@ function ThreadListItemImpl({
   onPreview,
   booklistComment,
   index = 0,
+  animateIn = true,
 }: ThreadListItemProps) {
   const {
     fontSizes,
@@ -58,10 +60,15 @@ function ThreadListItemImpl({
   const { measureRef: titleMeasureRef, clampedText: clampedTitle } =
     usePretextClampText<HTMLHeadingElement>(thread.title, { maxLines: 2 });
 
+  // 缓存命中直出的页面传 animateIn=false：内容用户已看过，不再重播浮现动画。
+  const entranceClass = animateIn
+    ? " animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both"
+    : "";
+
   return (
     <article
-      className="group relative w-full cursor-pointer py-3 text-(--od-text-primary) [content-visibility:auto] [contain-intrinsic-size:auto_200px] transition-colors duration-200 animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both"
-      style={{ animationDelay }}
+      className={`group relative w-full cursor-pointer py-3 text-(--od-text-primary) [content-visibility:auto] [contain-intrinsic-size:auto_200px] transition-colors duration-200${entranceClass}`}
+      style={animateIn ? { animationDelay } : undefined}
       onClick={() => onPreview?.(thread)}
     >
       <div className="absolute inset-x-0 bottom-0 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_srgb,var(--od-divider-strong)_60%,transparent),transparent)]" />

--- a/src/entities/thread/ThreadListItem.tsx
+++ b/src/entities/thread/ThreadListItem.tsx
@@ -60,7 +60,7 @@ function ThreadListItemImpl({
 
   return (
     <article
-      className="group relative w-full cursor-pointer py-3 text-(--od-text-primary) transition-colors duration-200 animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both"
+      className="group relative w-full cursor-pointer py-3 text-(--od-text-primary) [content-visibility:auto] [contain-intrinsic-size:auto_200px] transition-colors duration-200 animate-in fade-in slide-in-from-bottom-2 duration-700 fill-mode-both"
       style={{ animationDelay }}
       onClick={() => onPreview?.(thread)}
     >

--- a/src/entities/thread/ThreadResultsCollection.tsx
+++ b/src/entities/thread/ThreadResultsCollection.tsx
@@ -14,6 +14,7 @@ interface ThreadResultsCollectionProps {
   gridClassName?: string;
   listClassName?: string;
   layoutMode?: LayoutMode;
+  animateIn?: boolean;
 }
 
 const DEFAULT_GRID_CLASS = 'grid auto-rows-fr grid-cols-2 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4';
@@ -59,6 +60,7 @@ function ThreadResultsCollectionImpl({
   gridClassName = DEFAULT_GRID_CLASS,
   listClassName = DEFAULT_LIST_CLASS,
   layoutMode: controlledLayoutMode,
+  animateIn,
 }: ThreadResultsCollectionProps) {
   const fallbackLayoutMode = useLayoutMode();
   const layoutMode = controlledLayoutMode ?? fallbackLayoutMode;
@@ -140,6 +142,7 @@ function ThreadResultsCollectionImpl({
                   searchQuery={searchQuery}
                   onAuthorClick={onAuthorClick}
                   onPreview={onPreview}
+                  animateIn={animateIn}
                   hideBottomDivider
                   masonry
                 />
@@ -163,6 +166,7 @@ function ThreadResultsCollectionImpl({
             searchQuery={searchQuery}
             onAuthorClick={onAuthorClick}
             onPreview={onPreview}
+            animateIn={animateIn}
           />
         ) : (
           <ThreadCard
@@ -173,6 +177,7 @@ function ThreadResultsCollectionImpl({
             searchQuery={searchQuery}
             onAuthorClick={onAuthorClick}
             onPreview={onPreview}
+            animateIn={animateIn}
           />
         ),
       )}

--- a/src/features/search/hooks/usePreviewThread.ts
+++ b/src/features/search/hooks/usePreviewThread.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { usePreviewStore } from '@/features/search/store/previewStore';
 import type { Thread } from '@/entities/thread/types';
 import { addBrowseHistory } from '@/shared/lib/browseHistory';
@@ -6,14 +8,22 @@ export function usePreviewThread() {
   const setPreviewThread = usePreviewStore((state) => state.setPreviewThread);
   const setPreviewThreadId = usePreviewStore((state) => state.setPreviewThreadId);
 
-  const openPreview = (thread: Thread) => {
-    addBrowseHistory(thread);
-    setPreviewThread(thread);
-  };
+  // useCallback 保证引用稳定：openPreview 会作为 onPreview 传给 memo 化的
+  // ThreadCard / ThreadListItem，引用一变整个列表的 memo 就全部失效。
+  const openPreview = useCallback(
+    (thread: Thread) => {
+      addBrowseHistory(thread);
+      setPreviewThread(thread);
+    },
+    [setPreviewThread],
+  );
 
-  const openPreviewById = (threadId: string) => {
-    setPreviewThreadId(threadId);
-  };
+  const openPreviewById = useCallback(
+    (threadId: string) => {
+      setPreviewThreadId(threadId);
+    },
+    [setPreviewThreadId],
+  );
 
   return {
     openPreview,

--- a/src/pages/BooklistDetailPage/index.tsx
+++ b/src/pages/BooklistDetailPage/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteScrollTrigger } from "@/shared/hooks/useInfiniteScrollTrigger";
+import { useListEntranceAnimation } from "@/shared/hooks/useListEntranceAnimation";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -130,6 +131,9 @@ export function BooklistDetailPage() {
   // ─── 无限滚动触发器 ──────────────────────────────────────
   // 必须放在提前返回之前，遵循 Hooks 规则
   const loadMoreRef = useInfiniteScrollTrigger(itemsQuery);
+  const animateIn = useListEntranceAnimation(
+    detailQuery.isLoading || itemsQuery.isLoading,
+  );
 
   if (!booklistId) {
     return <PageStatusMessage tone="error">无效书单 ID</PageStatusMessage>;
@@ -474,12 +478,14 @@ export function BooklistDetailPage() {
                       thread={threadFromBooklistItem(item)}
                       onPreview={openPreview}
                       booklistComment={item.comment || ""}
+                      animateIn={animateIn}
                     />
                   ) : (
                     <ThreadCard
                       thread={threadFromBooklistItem(item)}
                       onPreview={openPreview}
                       booklistComment={item.comment || ""}
+                      animateIn={animateIn}
                     />
                   )}
                   {isOwner && (

--- a/src/pages/MePage/MeFollowsSection.tsx
+++ b/src/pages/MePage/MeFollowsSection.tsx
@@ -2,6 +2,7 @@ import { BellOff, Bookmark, CheckCircle2, RefreshCw } from 'lucide-react';
 
 import { ThreadListItem } from '@/entities/thread/ThreadListItem';
 import type { Thread } from '@/entities/thread/types';
+import { useListEntranceAnimation } from '@/shared/hooks/useListEntranceAnimation';
 import { FluidDivider } from '@/shared/ui/FluidDivider';
 
 type FollowStatusFilter = 'current' | 'past' | 'all';
@@ -44,6 +45,8 @@ export function MeFollowsSection({
   onUnfollow,
   unfollowPendingThreadId,
 }: MeFollowsSectionProps) {
+  const animateIn = useListEntranceAnimation(isLoading);
+
   const emptyMessage = selectedChannel
     ? '这个频道里暂时没有符合筛选的关注内容。'
     : followStatus === 'past'
@@ -137,7 +140,12 @@ export function MeFollowsSection({
 
             return (
               <div key={thread.thread_id} className="relative md:pr-36">
-                <ThreadListItem thread={thread} index={index} onPreview={onPreview} />
+                <ThreadListItem
+                  thread={thread}
+                  index={index}
+                  onPreview={onPreview}
+                  animateIn={animateIn}
+                />
                 <div className="mt-2 flex justify-end md:absolute md:right-0 md:top-3 md:mt-0">
                   {isCurrentFollow ? (
                     <button

--- a/src/pages/MePage/MeThreadsSection.tsx
+++ b/src/pages/MePage/MeThreadsSection.tsx
@@ -2,6 +2,7 @@ import { FileText, RefreshCw } from 'lucide-react';
 
 import { ThreadResultsCollection } from '@/entities/thread/ThreadResultsCollection';
 import type { Thread } from '@/entities/thread/types';
+import { useListEntranceAnimation } from '@/shared/hooks/useListEntranceAnimation';
 import { FluidDivider } from '@/shared/ui/FluidDivider';
 
 interface MeThreadsSectionProps {
@@ -23,6 +24,8 @@ export function MeThreadsSection({
   onPreview,
   onRefresh,
 }: MeThreadsSectionProps) {
+  const animateIn = useListEntranceAnimation(isLoading);
+
   return (
     <section className="px-1">
       <FluidDivider label="Threads" className="mb-8" />
@@ -73,7 +76,11 @@ export function MeThreadsSection({
       ) : threads.length === 0 ? (
         <p className="od-text-body">还没有找到你创建的内容，可能还没被索引到。</p>
       ) : (
-        <ThreadResultsCollection threads={threads} onPreview={onPreview} />
+        <ThreadResultsCollection
+          threads={threads}
+          onPreview={onPreview}
+          animateIn={animateIn}
+        />
       )}
     </section>
   );

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -41,7 +41,7 @@ import {
   Search,
   SlidersHorizontal,
 } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 const searchSortOptions = [
@@ -130,10 +130,22 @@ export function SearchPage() {
     };
   }, [location.pathname, location.search]);
 
-  const handleTagClick = (tagName: string) => {
-    const nextQuery = addToken(query || "", "tag", tagName, "include");
-    setParams({ query: nextQuery });
-  };
+  // 这些回调会传给 memo 化的 ThreadResultsCollection / ThreadCard，
+  // 必须保持引用稳定，否则任何一次页面重渲染都会击穿整个列表的 memo。
+  const handleTagClick = useCallback(
+    (tagName: string) => {
+      const nextQuery = addToken(query || "", "tag", tagName, "include");
+      setParams({ query: nextQuery });
+    },
+    [query, setParams],
+  );
+
+  const handleAuthorClick = useCallback(
+    (author: { id: string; name: string }) => {
+      navigate(`/u/${author.id}`);
+    },
+    [navigate],
+  );
 
   const gridClass = useCardGridClass();
   const threadGridClass =
@@ -163,9 +175,12 @@ export function SearchPage() {
     hasTriggeredSearchCueRef.current = cueKey;
   }, [isError, isLoading, query, reactToSearch, totalResults]);
 
+  // 标题栏与偏好同步共用的解析结果，按 query 缓存
+  const queryTokens = useMemo(() => parseSearchQuery(query), [query]);
+
   // 同步用户偏好排序
   useEffect(() => {
-    const hasTextSearch = parseSearchQuery(query).some(
+    const hasTextSearch = queryTokens.some(
       (token) => token.type === "text" && token.value.trim(),
     );
     if (
@@ -185,7 +200,7 @@ export function SearchPage() {
         setParams({ sortMethod: preferredSort });
       }
     }
-  }, [preferences, params.sortMethod, query, setParams]);
+  }, [preferences, params.sortMethod, queryTokens, setParams]);
 
 
   const isThreadTab = params.type === "thread";
@@ -215,7 +230,7 @@ export function SearchPage() {
                 {query ? (
                   <>
                     <span>搜索:</span>
-                    {parseSearchQuery(query).map((token, i) => {
+                    {queryTokens.map((token, i) => {
                       if (token.type === "text") {
                         return (
                           <span
@@ -440,7 +455,7 @@ export function SearchPage() {
                 threads={results}
                 onTagClick={handleTagClick}
                 searchQuery={query}
-                onAuthorClick={(author) => navigate(`/u/${author.id}`)}
+                onAuthorClick={handleAuthorClick}
                 onPreview={openPreview}
                 gridClassName={threadGridClass}
                 listClassName="flex flex-col space-y-od-list-gap pb-4"

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -22,6 +22,7 @@ import {
   useSettings,
 } from "@/shared/hooks/useSettings";
 import { useLayoutPreference } from "@/shared/hooks/useLayoutPreference";
+import { useListEntranceAnimation } from "@/shared/hooks/useListEntranceAnimation";
 import { useMascotStore } from "@/features/mascot/store/mascotStore";
 import { useUserPreferences } from "@/features/preferences/hooks/useUserPreferences";
 import { PreferenceFilterNotice } from "@/features/preferences/components/PreferenceFilterNotice";
@@ -85,6 +86,8 @@ export function SearchPage() {
     setIgnoreDiscoveryPreferences,
     totalResults,
   } = useSearchResults({ params, preferences });
+
+  const animateIn = useListEntranceAnimation(isLoading);
 
   const booklistQuery = useBooklistsList({
     scope: "public",
@@ -460,6 +463,7 @@ export function SearchPage() {
                 gridClassName={threadGridClass}
                 listClassName="flex flex-col space-y-od-list-gap pb-4"
                 layoutMode={layoutMode}
+                animateIn={animateIn}
               />
 
               {isInfiniteMode ? (

--- a/src/pages/TournamentDetailPage/index.tsx
+++ b/src/pages/TournamentDetailPage/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useInfiniteScrollTrigger } from "@/shared/hooks/useInfiniteScrollTrigger";
+import { useListEntranceAnimation } from "@/shared/hooks/useListEntranceAnimation";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -70,6 +71,9 @@ export function TournamentDetailPage() {
   const detailQuery = useTournamentDetail(normalizedBooklistId);
   const itemsQuery = useTournamentItems(normalizedBooklistId);
   const loadMoreRef = useInfiniteScrollTrigger(itemsQuery);
+  const animateIn = useListEntranceAnimation(
+    detailQuery.isLoading || itemsQuery.isLoading,
+  );
   const collectMutation = useToggleBooklistCollection();
 
   const tournament = detailQuery.data;
@@ -378,12 +382,14 @@ export function TournamentDetailPage() {
                         thread={toTournamentThread(item, tournament)}
                         onPreview={openPreview}
                         booklistComment={item.comment || ""}
+                        animateIn={animateIn}
                       />
                     ) : (
                       <ThreadCard
                         thread={toTournamentThread(item, tournament)}
                         onPreview={openPreview}
                         booklistComment={item.comment || ""}
+                        animateIn={animateIn}
                       />
                     )}
                   </div>

--- a/src/pages/TournamentManagePage/index.tsx
+++ b/src/pages/TournamentManagePage/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { useInfiniteScrollTrigger } from "@/shared/hooks/useInfiniteScrollTrigger";
+import { useListEntranceAnimation } from "@/shared/hooks/useListEntranceAnimation";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -59,6 +60,9 @@ export function TournamentManagePage() {
   const detailQuery = useBooklistDetail(normalizedBooklistId);
   const itemsQuery = useBooklistItems(normalizedBooklistId);
   const loadMoreRef = useInfiniteScrollTrigger(itemsQuery);
+  const animateIn = useListEntranceAnimation(
+    detailQuery.isLoading || itemsQuery.isLoading,
+  );
   const tournament = detailQuery.data;
   const items = useMemo(() => {
     return itemsQuery.data?.pages.flatMap((page) => page.results || []) ?? [];
@@ -207,12 +211,14 @@ export function TournamentManagePage() {
                       thread={toTournamentThread(item)}
                       onPreview={openPreview}
                       booklistComment={item.comment || ""}
+                      animateIn={animateIn}
                     />
                   ) : (
                     <ThreadCard
                       thread={toTournamentThread(item)}
                       onPreview={openPreview}
                       booklistComment={item.comment || ""}
+                      animateIn={animateIn}
                     />
                   )}
                   <div className="mt-2 flex flex-wrap items-center justify-end gap-1 text-xs">

--- a/src/pages/UserProfilePage/index.tsx
+++ b/src/pages/UserProfilePage/index.tsx
@@ -33,6 +33,7 @@ import { useMascotStore } from "@/features/mascot/store/mascotStore";
 import { type UISortMethod } from "@/features/search/api/searchApi";
 import { usePreviewThread } from "@/features/search/hooks/usePreviewThread";
 import { useChannels } from "@/shared/hooks/useChannels";
+import { useListEntranceAnimation } from "@/shared/hooks/useListEntranceAnimation";
 import {
   buildAuthorShareText,
   copyTextToClipboard,
@@ -184,6 +185,7 @@ export function UserProfilePage() {
     sortMethod,
     channelIds: selectedChannelIds,
   });
+  const animateIn = useListEntranceAnimation(threadsQuery.isLoading);
 
   const profileQuery = useAuthorProfile(userId);
 
@@ -566,6 +568,7 @@ export function UserProfilePage() {
               <ThreadResultsCollection
                 threads={threads}
                 onPreview={openPreview}
+                animateIn={animateIn}
               />
             )}
           </section>

--- a/src/shared/hooks/useListEntranceAnimation.ts
+++ b/src/shared/hooks/useListEntranceAnimation.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+/**
+ * 列表入场动画开关的挂载快照。
+ * 挂载瞬间还在加载（无缓存数据）→ 播入场动画；缓存直出 → 跳过，
+ * 用户看过的内容不该再"浮现"一次。快照定死后不随 refetch 翻转，
+ * 避免已显示的卡片中途重播动画。
+ */
+export function useListEntranceAnimation(isLoadingAtMount: boolean): boolean {
+  const [animateIn] = useState(isLoadingAtMount);
+  return animateIn;
+}

--- a/src/shared/ui/DiscordMarkdownText.tsx
+++ b/src/shared/ui/DiscordMarkdownText.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 
 import { Spoiler } from '@/shared/ui/Spoiler';
 
@@ -7,15 +8,17 @@ interface DiscordMarkdownTextProps {
   truncateClassName?: string;
 }
 
-export function DiscordMarkdownText({ text, className = '', truncateClassName = '' }: DiscordMarkdownTextProps) {
-  if (!text) return null;
+type MarkdownPart =
+  | { type: 'text' | 'spoiler' | 'bold' | 'code'; content: string }
+  | { type: 'link'; text: string; url: string };
 
-  // 简易行内 Markdown 解析器
-  // 匹配: 链接 [text](url) | 粗体 **text** | 行内代码 `code`
+// 简易行内 Markdown 解析器
+// 匹配: 链接 [text](url) | 剧透 ||text|| | 粗体 **text** | 行内代码 `code`
+function parseDiscordMarkdown(text: string): MarkdownPart[] {
   const regex = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)|\|\|(.+?)\|\||\*\*([^*]+)\*\*|`([^`]+)`/g;
-  const parts = [];
+  const parts: MarkdownPart[] = [];
   let lastIndex = 0;
-  
+
   let match;
   while ((match = regex.exec(text)) !== null) {
     if (match.index > lastIndex) {
@@ -37,10 +40,20 @@ export function DiscordMarkdownText({ text, className = '', truncateClassName = 
 
     lastIndex = regex.lastIndex;
   }
-  
+
   if (lastIndex < text.length) {
     parts.push({ type: 'text', content: text.substring(lastIndex) });
   }
+
+  return parts;
+}
+
+export function DiscordMarkdownText({ text, className = '', truncateClassName = '' }: DiscordMarkdownTextProps) {
+  // 列表页每张卡片的摘要都要经过这里，解析结果按 text 缓存，
+  // 与 MarkdownText 的 useMemo 策略保持一致。
+  const parts = useMemo(() => (text ? parseDiscordMarkdown(text) : []), [text]);
+
+  if (!text) return null;
 
   return (
     <span className={`inline ${className} ${truncateClassName}`}>

--- a/src/shared/ui/LazyImage.tsx
+++ b/src/shared/ui/LazyImage.tsx
@@ -3,6 +3,10 @@ import { useImageModeSetting } from '@/shared/hooks/useSettings';
 import { reportBrokenThreadThumbnail, subscribeThreadThumbnailRepair } from '@/features/threads/lib/thumbnailRepairQueue';
 import { optimizeDiscordImageUrl } from '@/shared/lib/imageOptimization';
 
+// 会话内已完整显示过的图片 URL。路由切换会重建组件、重置 isLoaded，
+// 浏览器 HTTP 缓存挡不住浮现动画重播；看过的图片重挂时凭这份记忆直出成品。
+const sessionLoadedImages = new Set<string>();
+
 interface LazyImageProps {
   src: string;
   alt?: string;
@@ -30,14 +34,17 @@ export function LazyImage({
   imageIndex = 0,
   onNaturalSize,
 }: LazyImageProps) {
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [isInView, setIsInView] = useState(false);
-  const [currentSrc, setCurrentSrc] = useState(src);
+  const [currentSrc, setCurrentSrc] = useState(() => optimizeDiscordImageUrl(src, 800));
+  // 会话内看过的图片直接以成品呈现：跳过懒加载门槛，不再播浮现动画
+  const [isLoaded, setIsLoaded] = useState(() => sessionLoadedImages.has(currentSrc));
+  const [isInView, setIsInView] = useState(isLoaded);
   const imgRef = useRef<HTMLDivElement>(null);
   const imageMode = useImageModeSetting();
   const isImageDisabled = imageMode === 'off';
 
   useEffect(() => {
+    if (isInView) return;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -55,7 +62,7 @@ export function LazyImage({
     }
 
     return () => observer.disconnect();
-  }, []);
+  }, [isInView]);
 
   const imageRef = useRef<HTMLImageElement>(null);
 
@@ -63,7 +70,7 @@ export function LazyImage({
     // 对 Discord 图片源应用高清优化（主打 WebP 无损转换）
     const optimized = optimizeDiscordImageUrl(src, 800);
     setCurrentSrc(optimized);
-    setIsLoaded(false);
+    setIsLoaded(sessionLoadedImages.has(optimized));
   }, [src]);
 
   useEffect(() => {
@@ -124,6 +131,7 @@ export function LazyImage({
                 transitionDelay: isLoaded ? `${(index % 24) * 60}ms` : '0ms',
               }}
               onLoad={() => {
+                sessionLoadedImages.add(currentSrc);
                 if (imageRef.current) {
                   onNaturalSize?.(
                     imageRef.current.naturalWidth,


### PR DESCRIPTION
## 概述

本 PR 包含两大块工作（22 个 commit）：

1. **2026-07-26 代码审查报告的四阶段整改**（30 条路线图全部落地，报告见 `docs/code-review-2026-07-26.md`）
2. **渲染与缓存性能优化**（memo 失效链修复、轻量虚拟化、缓存命中跳过入场动画）

## 主要变更

### 整改（chore/code-review-fixes 段，18 commits）
- **正确性修复**：Snowflake ID 精度损坏、无限滚动死循环、搜索缓存被打穿、无效 color-mix 语法、全站轮询与抽卡黑屏
- **架构清理**：解除 booklists ⇄ tournaments 循环依赖（madge 验证无环）；抽取 `useInfiniteScrollTrigger`、`threadFromBooklistItem`、`LayoutModeToggle`、`PageStatusMessage` 等共享件；拆分 ThreadCard/ThreadListItem 同构逻辑到 `useThreadCardModel`；ThemeProvider 300 行巨型 effect 拆为 4 个纯函数 + 60 行编排层
- **质量门禁**：重建五道 CI 门禁（tsc / eslint / stylelint / vitest / build），lint 棘轮基线 93；补 authApi 单元测试与 jsdom 全局 stub（94 用例）
- **打包优化**：拆分产物、剔除未使用依赖

### 性能优化（perf 段，4 commits）
- **memo 失效链修复**：`usePreviewThread` 等回调 useCallback 化，7 个页面的列表 memo 不再被每渲染新建的引用击穿；DiscordMarkdownText 解析、parseSearchQuery 按输入缓存
- **轻量虚拟化**：长列表卡片加 `content-visibility: auto` + `contain-intrinsic-size`，屏外卡片跳过渲染（附跑马灯测量对 `contentvisibilityautostatechange` 的补测）
- **缓存命中跳过入场动画**：卡片新增 `animateIn` 开关，7 个消费页按"挂载瞬间是否有缓存数据"快照决定（`useListEntranceAnimation`），快照不随 refetch 翻转；LazyImage 增加会话级 `sessionLoadedImages` 记忆，看过的图片路由切回时直出成品，不再重播 1s 浮现动画

## 验证

- `npx tsc -b`：0 错误
- `npx vitest run`：25 文件 / 94 用例全过
- `npm run lint`：93 警告（基线内，0 错误）
- `npm run build`：构建成功

## Reviewer 须知

- 报告第 22 条（自定义 @utility 加 od- 前缀）复核后**决定不改**：双定义实际是 transition 与 animation 各自生效、危害低，改动波及 51 处且 19 处动画会退化，理由已记录在报告附录
- LazyImage / animateIn 的"缓存直出不播动画"依赖会话级内存记忆（模块级 Set / 挂载快照），刷新页面后首次加载仍正常播动画，属预期行为
- content-visibility 与动画跳过的浏览器人工验证建议合并前在本地过一遍（dev 环境自动化实测因工具故障未完成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)