### PR TITLE
feat: 429 阻断用户搜索

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,12 @@ import { showMascotErrorToast } from '@/features/mascot/lib/mascotToast';
 import { ThemeProvider } from '@/app/themes/ThemeProvider';
 import { bindThumbnailRepairQueryClient } from '@/features/threads/lib/thumbnailRepairQueue';
 import { consumeAuthTokenFromHash } from '@/shared/lib/authSession';
+import {
+  getRateLimitInfo,
+  isSilentPreloadRateLimit,
+  shouldRetryQuery,
+} from '@/shared/api/rateLimit';
+import { notifyRateLimit } from '@/shared/lib/notify';
 import { router } from './router';
 import { useMascotStore } from '@/features/mascot/store/mascotStore';
 
@@ -15,6 +21,11 @@ const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error) => {
       console.error('Global Query Error:', error);
+      const rateLimit = getRateLimitInfo(error);
+      if (rateLimit) {
+        if (!isSilentPreloadRateLimit(error)) notifyRateLimit(rateLimit);
+        return;
+      }
       showMascotErrorToast('network', { id: 'global-network-error' });
     },
   }),
@@ -22,14 +33,14 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false, // Prevent aggressive re-fetching when switching back
-      retry: 1,
+      retry: shouldRetryQuery,
     },
   },
 });
 
 // 方便调试
 if (import.meta.env.DEV) {
-  (window as any).queryClient = queryClient;
+  Object.assign(window, { queryClient });
 }
 
 export function App() {

--- a/src/features/search/api/searchApi.test.ts
+++ b/src/features/search/api/searchApi.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiClient } from "@/shared/api/client";
+import {
+  RateLimitError,
+  resetRateLimitStateForTests,
+} from "@/shared/api/rateLimit";
 import { searchApi } from "./searchApi";
 
 vi.mock("@/shared/api/client", () => ({
@@ -9,9 +13,25 @@ vi.mock("@/shared/api/client", () => ({
 
 describe("searchApi 作者 Token", () => {
   beforeEach(() => {
+    resetRateLimitStateForTests();
     vi.mocked(apiClient.post).mockResolvedValue({
       data: { total: 0, results: [] },
     });
+  });
+
+  it("后台预加载 429 会记录冷却时间，后续请求在本地被拦截", async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce({
+      isAxiosError: true,
+      config: { url: "/search/" },
+      response: { status: 429, headers: { "retry-after": "5" } },
+    });
+
+    await expect(searchApi.search({}, undefined, "preload")).rejects.toMatchObject({
+      name: "RateLimitError",
+      rateLimit: { origin: "preload", retryAfterSeconds: 5 },
+    });
+    await expect(searchApi.search({})).rejects.toBeInstanceOf(RateLimitError);
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
   });
 
   it("把正反作者 ID 放进对应请求字段", async () => {

--- a/src/features/search/api/searchApi.ts
+++ b/src/features/search/api/searchApi.ts
@@ -1,5 +1,12 @@
 import { SearchParams as ApiSearchParams, SearchResponse, SimilarThreadsResponse, Thread } from '@/entities/thread/types';
 import { apiClient } from '@/shared/api/client';
+import {
+  getActiveRateLimit,
+  getRateLimitInfo,
+  RateLimitError,
+  rememberRateLimit,
+  type RateLimitOrigin,
+} from '@/shared/api/rateLimit';
 import { tokenizeSearchPayload } from '@/shared/lib/searchTokenizer';
 
 export type UISortMethod =
@@ -237,12 +244,25 @@ function buildSearchRequest(params: SearchUIRequest): ApiSearchParams {
 }
 
 export const searchApi = {
-  search: async (params: SearchUIRequest = {}, signal?: AbortSignal): Promise<SearchResponse> => {
+  search: async (
+    params: SearchUIRequest = {},
+    signal?: AbortSignal,
+    origin: RateLimitOrigin = 'foreground',
+  ): Promise<SearchResponse> => {
+    const activeRateLimit = getActiveRateLimit('search', origin);
+    if (activeRateLimit) throw new RateLimitError(activeRateLimit);
+
     const requestBody = buildSearchRequest(params);
-    const response = signal
-      ? await apiClient.post<SearchResponse>('/search/', requestBody, { signal })
-      : await apiClient.post<SearchResponse>('/search/', requestBody);
-    return response.data;
+    try {
+      const response = signal
+        ? await apiClient.post<SearchResponse>('/search/', requestBody, { signal })
+        : await apiClient.post<SearchResponse>('/search/', requestBody);
+      return response.data;
+    } catch (error) {
+      const rateLimit = getRateLimitInfo(error, { scope: 'search', origin });
+      if (!rateLimit) throw error;
+      throw new RateLimitError(rememberRateLimit(rateLimit), error);
+    }
   },
 
   getThread: async (threadId: string, signal?: AbortSignal): Promise<Thread> => {

--- a/src/features/search/hooks/useSearchResults.rateLimit.test.tsx
+++ b/src/features/search/hooks/useSearchResults.rateLimit.test.tsx
@@ -1,0 +1,176 @@
+import type { PropsWithChildren } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SearchResponse } from "@/entities/thread/types";
+import { searchApi } from "@/features/search/api/searchApi";
+import type { SearchParams } from "@/features/search/hooks/useSearchParams";
+import {
+  RateLimitError,
+  rememberRateLimit,
+  resetRateLimitStateForTests,
+  type RateLimitOrigin,
+} from "@/shared/api/rateLimit";
+import { notifyRateLimit } from "@/shared/lib/notify";
+import { useSearchResults } from "./useSearchResults";
+
+vi.mock("@/features/search/api/searchApi", () => ({
+  searchApi: { search: vi.fn() },
+}));
+
+const settings = vi.hoisted(() => ({
+  pagingMode: "infinite" as "infinite" | "pagination",
+  preload: { enabled: true, pages: 2 },
+}));
+
+vi.mock("@/shared/hooks/useSettings", () => ({
+  useResultPagingModeSetting: () => settings.pagingMode,
+  useResultPreloadSettings: () => settings.preload,
+}));
+
+vi.mock("@/shared/lib/notify", () => ({
+  notifyRateLimit: vi.fn(),
+}));
+
+const params: SearchParams = {
+  query: "",
+  channel: null,
+  type: "thread",
+  sortMethod: "last_active_desc",
+  sortOrder: "desc",
+  page: 1,
+  includeTags: [],
+  excludeTags: [],
+  includeAuthors: [],
+  excludeAuthors: [],
+  tagLogic: "and",
+  timeFrom: "",
+  timeTo: "",
+  reactionMin: null,
+  replyMin: null,
+};
+
+const page = (ids: string[], total = 10) =>
+  ({
+    total,
+    limit: 24,
+    offset: 0,
+    results: ids.map((threadId) => ({ thread_id: threadId })),
+    available_tags: [],
+    virtual_tags: [],
+  }) as unknown as SearchResponse;
+
+function rateLimit(origin: RateLimitOrigin) {
+  return rememberRateLimit({
+    scope: "search",
+    origin,
+    retryAfterSeconds: 5,
+    retryAt: Date.now() + 5_000,
+  });
+}
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useSearchResults 限流分层", () => {
+  beforeEach(() => {
+    resetRateLimitStateForTests();
+    vi.clearAllMocks();
+    settings.pagingMode = "infinite";
+    settings.preload = { enabled: true, pages: 2 };
+  });
+
+  afterEach(() => {
+    resetRateLimitStateForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("后台预加载 429 时保留当前结果并静默暂停", async () => {
+    vi.mocked(searchApi.search)
+      .mockResolvedValueOnce(page(["1"]))
+      .mockImplementationOnce(async () => {
+        throw new RateLimitError(rateLimit("preload"));
+      });
+
+    const { result } = renderHook(
+      () => useSearchResults({ params, preferences: null }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(searchApi.search).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(result.current.infiniteQueryState.isFetchNextPageError).toBe(true),
+    );
+
+    expect(result.current.results).toHaveLength(1);
+    expect(result.current.visibleRateLimit).toBeNull();
+    expect(notifyRateLimit).not.toHaveBeenCalled();
+
+    await act(async () => result.current.requestNextPage());
+    expect(searchApi.search).toHaveBeenCalledTimes(2);
+    expect(result.current.visibleRateLimit?.remaining).toBeGreaterThan(0);
+    expect(notifyRateLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("第一批搜索 429 时立即提供页面限流状态", async () => {
+    vi.mocked(searchApi.search).mockImplementationOnce(async () => {
+      throw new RateLimitError(rateLimit("foreground"));
+    });
+
+    const { result } = renderHook(
+      () => useSearchResults({ params, preferences: null }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(result.current.infiniteQueryState.isError).toBe(true),
+    );
+    await waitFor(() => expect(result.current.visibleRateLimit).not.toBeNull());
+    expect(result.current.results).toHaveLength(0);
+  });
+
+  it("分页请求 429 后，冷却结束再次翻页会重新请求", async () => {
+    settings.pagingMode = "pagination";
+    settings.preload = { enabled: false, pages: 2 };
+    let now = 10_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.mocked(searchApi.search)
+      .mockResolvedValueOnce(page(["1"]))
+      .mockImplementationOnce(async () => {
+        throw new RateLimitError(rateLimit("foreground"));
+      })
+      .mockResolvedValueOnce(page(["2"]));
+
+    let currentParams = params;
+    const { result, rerender } = renderHook(
+      () => useSearchResults({ params: currentParams, preferences: null }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    currentParams = { ...params, page: 2 };
+    rerender();
+    await waitFor(() =>
+      expect(result.current.infiniteQueryState.isFetchNextPageError).toBe(true),
+    );
+
+    currentParams = params;
+    rerender();
+    now += 6_000;
+    expect(result.current.preparePageRequest(2)).toBe(true);
+    currentParams = { ...params, page: 2 };
+    rerender();
+
+    await waitFor(() => expect(searchApi.search).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(result.current.results[0]?.thread_id).toBe("2"));
+  });
+});

--- a/src/features/search/hooks/useSearchResults.ts
+++ b/src/features/search/hooks/useSearchResults.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
 
@@ -13,10 +13,19 @@ import {
   type SearchParams,
 } from '@/features/search/hooks/useSearchParams';
 import { searchKeys } from '@/features/search/lib/queryKeys';
+import { SEARCH_SUBMIT_EVENT } from '@/features/search/lib/searchEvents';
+import {
+  getActiveRateLimit,
+  getRateLimitInfo,
+  getRemainingRateLimitSeconds,
+  type RateLimitInfo,
+  type RateLimitOrigin,
+} from '@/shared/api/rateLimit';
 import {
   useResultPagingModeSetting,
   useResultPreloadSettings,
 } from '@/shared/hooks/useSettings';
+import { notifyRateLimit } from '@/shared/lib/notify';
 
 interface UseSearchResultsOptions {
   params: SearchParams;
@@ -101,6 +110,11 @@ export function useSearchResults({ params, preferences }: UseSearchResultsOption
   } = params;
 
   const [ignoreDiscoveryPreferences, setIgnoreDiscoveryPreferences] = useState(false);
+  const [preloadPaused, setPreloadPaused] = useState(false);
+  const [visibleRateLimit, setVisibleRateLimit] = useState<RateLimitInfo | null>(null);
+  const [rateLimitClock, setRateLimitClock] = useState(() => Date.now());
+  const nextPageOriginRef = useRef<RateLimitOrigin>('foreground');
+  const attemptedForegroundPageRef = useRef<number | null>(null);
   const resultPagingMode = useResultPagingModeSetting();
   const resultPreload = useResultPreloadSettings();
   const currentPage = Math.max(1, page || 1);
@@ -157,23 +171,29 @@ export function useSearchResults({ params, preferences }: UseSearchResultsOption
     }),
     queryFn: ({ pageParam }) => {
       const excludeThreadIds = pageParam;
-      return searchApi.search({
-        query: query || undefined,
-        channel_ids: selectedChannel ? [selectedChannel] : undefined,
-        include_tags: includeTags.length > 0 ? includeTags : undefined,
-        exclude_tags: excludeTags.length > 0 ? excludeTags : undefined,
-        tag_logic: tagLogic,
-        sort_method: sortMethod,
-        sort_order: sortOrder,
-        apply_preferences: applyPreferences,
-        limit: PAGE_SIZE,
-        offset: 0,
-        exclude_thread_ids: excludeThreadIds,
-        created_after: timeFrom || undefined,
-        created_before: timeTo || undefined,
-        reaction_min: reactionMin,
-        reply_min: replyMin,
-      });
+      const origin =
+        excludeThreadIds.length > 0 ? nextPageOriginRef.current : 'foreground';
+      return searchApi.search(
+        {
+          query: query || undefined,
+          channel_ids: selectedChannel ? [selectedChannel] : undefined,
+          include_tags: includeTags.length > 0 ? includeTags : undefined,
+          exclude_tags: excludeTags.length > 0 ? excludeTags : undefined,
+          tag_logic: tagLogic,
+          sort_method: sortMethod,
+          sort_order: sortOrder,
+          apply_preferences: applyPreferences,
+          limit: PAGE_SIZE,
+          offset: 0,
+          exclude_thread_ids: excludeThreadIds,
+          created_after: timeFrom || undefined,
+          created_before: timeTo || undefined,
+          reaction_min: reactionMin,
+          reply_min: replyMin,
+        },
+        undefined,
+        origin,
+      );
     },
     initialPageParam: [],
     getNextPageParam: (_lastPage, allPages = []) => computeNextExcludeIds(allPages),
@@ -181,11 +201,37 @@ export function useSearchResults({ params, preferences }: UseSearchResultsOption
   });
 
   const loadedPageCount = infiniteQueryState.data?.pages.length || 0;
-  const {
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = infiniteQueryState;
+  const { fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
+    infiniteQueryState;
+
+  const revealRateLimit = useCallback((info: RateLimitInfo) => {
+    const visibleInfo = { ...info, origin: 'foreground' as const };
+    setRateLimitClock(Date.now());
+    setVisibleRateLimit(visibleInfo);
+    notifyRateLimit(visibleInfo);
+  }, []);
+
+  const revealActiveRateLimit = useCallback(() => {
+    const activeRateLimit = getActiveRateLimit('search', 'foreground');
+    if (!activeRateLimit) return false;
+    setPreloadPaused(true);
+    revealRateLimit(activeRateLimit);
+    return true;
+  }, [revealRateLimit]);
+
+  const fetchNextPageWithOrigin = useCallback(
+    async (origin: RateLimitOrigin) => {
+      nextPageOriginRef.current = origin;
+      const result = await fetchNextPage();
+      if (!result.isError && origin === 'foreground') {
+        attemptedForegroundPageRef.current = null;
+        setPreloadPaused(false);
+        setVisibleRateLimit(null);
+      }
+      return result;
+    },
+    [fetchNextPage],
+  );
 
   const viewedPage =
     resultPagingMode === 'pagination'
@@ -200,49 +246,178 @@ export function useSearchResults({ params, preferences }: UseSearchResultsOption
   );
 
   useEffect(() => {
+    nextPageOriginRef.current = 'foreground';
+    attemptedForegroundPageRef.current = null;
+    const timer = window.setTimeout(() => {
+      const activeRateLimit = getActiveRateLimit('search', 'foreground');
+      setPreloadPaused(Boolean(activeRateLimit));
+      if (activeRateLimit) {
+        revealRateLimit(activeRateLimit);
+      } else {
+        setVisibleRateLimit(null);
+      }
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [resultSignature, revealRateLimit]);
+
+  useEffect(() => {
+    const rateLimit = getRateLimitInfo(infiniteQueryState.error);
+    if (!rateLimit) return;
+
+    const timer = window.setTimeout(() => {
+      setPreloadPaused(true);
+      if (rateLimit.origin === 'preload') return;
+      setRateLimitClock(Date.now());
+      setVisibleRateLimit(rateLimit);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [infiniteQueryState.error]);
+
+  useEffect(() => {
+    if (!visibleRateLimit?.retryAt) return;
+    const timer = window.setInterval(() => {
+      const now = Date.now();
+      setRateLimitClock(now);
+      if (
+        visibleRateLimit.retryAt !== null &&
+        visibleRateLimit.retryAt <= now
+      ) {
+        setVisibleRateLimit(null);
+        window.clearInterval(timer);
+      }
+    }, 250);
+    return () => window.clearInterval(timer);
+  }, [visibleRateLimit]);
+
+  const visibleRateLimitRemaining = visibleRateLimit
+    ? getRemainingRateLimitSeconds(visibleRateLimit, rateLimitClock)
+    : null;
+
+  useEffect(() => {
+    const needsForegroundPage = loadedPageCount < viewedPage;
     if (
       requestedPageCount <= loadedPageCount ||
       !hasNextPage ||
-      isFetchingNextPage
+      isFetchingNextPage ||
+      (!needsForegroundPage &&
+        (preloadPaused || infiniteQueryState.isFetchNextPageError)) ||
+      (needsForegroundPage &&
+        infiniteQueryState.isFetchNextPageError &&
+        attemptedForegroundPageRef.current === viewedPage)
     ) {
       return;
     }
 
-    void fetchNextPage();
+    if (needsForegroundPage) {
+      const activeRateLimit = getActiveRateLimit('search', 'foreground');
+      if (activeRateLimit) {
+        const timer = window.setTimeout(() => {
+          setPreloadPaused(true);
+          revealRateLimit(activeRateLimit);
+        }, 0);
+        return () => window.clearTimeout(timer);
+      }
+    }
+
+    const origin: RateLimitOrigin = needsForegroundPage
+      ? 'foreground'
+      : 'preload';
+    if (origin === 'foreground')
+      attemptedForegroundPageRef.current = viewedPage;
+    const timer = window.setTimeout(() => {
+      void fetchNextPageWithOrigin(origin);
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [
-    fetchNextPage,
+    fetchNextPageWithOrigin,
+    hasNextPage,
+    infiniteQueryState.isFetchNextPageError,
+    isFetchingNextPage,
+    loadedPageCount,
+    preloadPaused,
+    revealRateLimit,
+    requestedPageCount,
+    viewedPage,
+  ]);
+
+  const reportViewedPage = useCallback(
+    (pageNumber: number) => {
+      const normalizedPage = Math.max(1, Math.floor(pageNumber));
+      setViewedPageState((current) => {
+        if (
+          current.signature === resultSignature &&
+          current.page >= normalizedPage
+        ) {
+          return current;
+        }
+        return {
+          signature: resultSignature,
+          page:
+            current.signature === resultSignature
+              ? Math.max(current.page, normalizedPage)
+              : normalizedPage,
+        };
+      });
+    },
+    [resultSignature],
+  );
+
+  const requestNextPage = useCallback(() => {
+    if (isFetchingNextPage || !hasNextPage || revealActiveRateLimit()) return;
+    reportViewedPage(Math.max(1, loadedPageCount));
+    void fetchNextPageWithOrigin('foreground');
+  }, [
+    fetchNextPageWithOrigin,
     hasNextPage,
     isFetchingNextPage,
     loadedPageCount,
-    requestedPageCount,
+    reportViewedPage,
+    revealActiveRateLimit,
   ]);
 
-  const reportViewedPage = useCallback((pageNumber: number) => {
-    const normalizedPage = Math.max(1, Math.floor(pageNumber));
-    setViewedPageState((current) => {
-      if (
-        current.signature === resultSignature &&
-        current.page >= normalizedPage
-      ) {
-        return current;
-      }
-      return {
-        signature: resultSignature,
-        page:
-          current.signature === resultSignature
-            ? Math.max(current.page, normalizedPage)
-            : normalizedPage,
-      };
-    });
-  }, [resultSignature]);
+  const preparePageRequest = useCallback(
+    (pageNumber: number) => {
+      if (pageNumber <= loadedPageCount) return true;
+      if (revealActiveRateLimit()) return false;
+      attemptedForegroundPageRef.current = null;
 
-  const requestNextPage = useCallback(() => {
-    if (resultPreload.enabled) {
-      reportViewedPage(Math.max(1, loadedPageCount));
-      return;
-    }
-    void fetchNextPage();
-  }, [fetchNextPage, loadedPageCount, reportViewedPage, resultPreload.enabled]);
+      if (
+        pageNumber === currentPage &&
+        infiniteQueryState.isFetchNextPageError &&
+        !isFetchingNextPage
+      ) {
+        attemptedForegroundPageRef.current = null;
+        void fetchNextPageWithOrigin('foreground');
+        return false;
+      }
+      return true;
+    },
+    [
+      currentPage,
+      fetchNextPageWithOrigin,
+      infiniteQueryState.isFetchNextPageError,
+      isFetchingNextPage,
+      loadedPageCount,
+      revealActiveRateLimit,
+    ],
+  );
+
+  useEffect(() => {
+    const handleSearchSubmit = () => {
+      if (revealActiveRateLimit()) return;
+      nextPageOriginRef.current = 'foreground';
+      attemptedForegroundPageRef.current = null;
+      setPreloadPaused(false);
+      setVisibleRateLimit(null);
+      void refetch().then((result) => {
+        if (!result.isError) setPreloadPaused(false);
+      });
+    };
+
+    window.addEventListener(SEARCH_SUBMIT_EVENT, handleSearchSubmit);
+    return () =>
+      window.removeEventListener(SEARCH_SUBMIT_EVENT, handleSearchSubmit);
+  }, [refetch, revealActiveRateLimit]);
 
   const results = useMemo<Thread[]>(() => {
     if (resultPagingMode === 'infinite') {
@@ -276,6 +451,8 @@ export function useSearchResults({ params, preferences }: UseSearchResultsOption
     showPreferenceBanner,
     pageSize: PAGE_SIZE,
     pageByThreadId,
+    loadedPageCount,
+    preparePageRequest,
     queryState: {
       ...infiniteQueryState,
       isLoading: infiniteQueryState.isLoading || isLoadingRequestedPage,
@@ -286,5 +463,8 @@ export function useSearchResults({ params, preferences }: UseSearchResultsOption
     reportViewedPage,
     setIgnoreDiscoveryPreferences,
     totalResults,
+    visibleRateLimit: visibleRateLimit
+      ? { info: visibleRateLimit, remaining: visibleRateLimitRemaining }
+      : null,
   };
 }

--- a/src/features/search/hooks/useTopBarSearchController.ts
+++ b/src/features/search/hooks/useTopBarSearchController.ts
@@ -19,6 +19,7 @@ import {
   getSearchTagLogicPreference,
   type SearchParams,
 } from "@/features/search/hooks/useSearchParams";
+import { dispatchSearchSubmit } from "@/features/search/lib/searchEvents";
 
 const SEARCH_DRAFT_QUERY_KEY = "odysseia_search_draft_query";
 const SEARCH_DRAFT_CHANNEL_KEY = "odysseia_search_draft_channel";
@@ -160,7 +161,9 @@ export function useTopBarSearchController({
           `/search${nextParams.toString() ? `?${nextParams.toString()}` : ""}`,
         );
       } else {
+        const isSameSearch = trimmed === params.query;
         setParams({ query: trimmed, page: 1 });
+        if (isSameSearch) dispatchSearchSubmit();
       }
 
       if (trimmed) {
@@ -183,6 +186,7 @@ export function useTopBarSearchController({
       params.channel,
       params.excludeTags,
       params.includeTags,
+      params.query,
       params.sortMethod,
       params.tagLogic,
       setParams,
@@ -215,7 +219,7 @@ export function useTopBarSearchController({
         setParams({ query: trimmed, page: 1 });
       }
     },
-    [isSearchPage, navigate, params.query, setParams],
+    [isSearchPage, navigate, params.channel, params.query, setParams],
   );
 
   const handleSearch = useCallback(() => {

--- a/src/features/search/lib/searchEvents.ts
+++ b/src/features/search/lib/searchEvents.ts
@@ -1,0 +1,5 @@
+export const SEARCH_SUBMIT_EVENT = "odysseia:search-submit";
+
+export function dispatchSearchSubmit() {
+  window.dispatchEvent(new Event(SEARCH_SUBMIT_EVENT));
+}

--- a/src/pages/AuthPage/LoginPage.tsx
+++ b/src/pages/AuthPage/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type CSSProperties } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Eye, EyeOff } from 'lucide-react';
 import { DiscordIcon } from '@/shared/ui/icons/DiscordIcon';
 import { useAuth, useRefreshAuth } from '@/features/auth/hooks/useAuth';
@@ -14,9 +14,11 @@ import { WordLoader } from '@/shared/ui/loaders/WordLoader';
 import { ImageViewer } from '@/shared/ui/ImageViewer';
 import { useImageViewerStore } from '@/shared/store/useImageViewerStore';
 import { AuthSceneBackground } from './AuthSceneBackground';
+import { clearLoginErrorParams, normalizeLoginError } from './loginError';
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { isAuthenticated } = useAuth();
   const refreshAuth = useRefreshAuth();
   const openImageViewer = useImageViewerStore((state) => state.open);
@@ -30,6 +32,25 @@ export function LoginPage() {
   const loadingWordStyle: CSSProperties & { '--od-text-primary': string } = {
     '--od-text-primary': 'color-mix(in oklab, var(--od-accent) 78%, white 22%)',
   };
+
+  // OAuth 失败返回登录页时，在顶部展示一次具体原因并清理错误参数
+  useEffect(() => {
+    const rawError = searchParams.get('error');
+    if (rawError === null) return;
+
+    const errorMessage = normalizeLoginError(rawError);
+    setSearchParams(clearLoginErrorParams(searchParams), { replace: true });
+
+    if (!errorMessage) return;
+    showMascotToast({
+      id: 'login-oauth-error',
+      emotion: 'sad_apology',
+      eyebrow: 'Login Interrupted',
+      title: '这次登录没接上',
+      message: errorMessage,
+      duration: 9000,
+    });
+  }, [searchParams, setSearchParams]);
 
   useEffect(() => {
     const timerId = window.setTimeout(() => setIsLoginCardReady(true), 10_000);

--- a/src/pages/AuthPage/loginError.test.ts
+++ b/src/pages/AuthPage/loginError.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { clearLoginErrorParams, normalizeLoginError } from './loginError';
+
+describe('normalizeLoginError', () => {
+  it('保留后端返回的具体原因并合并异常空白', () => {
+    expect(normalizeLoginError('  Discord 身份组服务\n暂时不可用。  ')).toBe(
+      'Discord 身份组服务 暂时不可用。',
+    );
+  });
+
+  it('缺少或为空的错误原因不显示提示', () => {
+    expect(normalizeLoginError(null)).toBeNull();
+    expect(normalizeLoginError(' \n\t ')).toBeNull();
+  });
+
+  it('将超长内容限制为 240 字并保持 HTML 为普通文本', () => {
+    const rawError = `<script>alert('x')</script>${'错'.repeat(300)}`;
+    const normalized = normalizeLoginError(rawError);
+
+    expect(normalized).toHaveLength(240);
+    expect(normalized).toContain("<script>alert('x')</script>");
+  });
+});
+
+describe('clearLoginErrorParams', () => {
+  it('删除 error 和 status，同时保留其他登录参数', () => {
+    const params = new URLSearchParams(
+      'error=Discord%E6%9A%82%E6%97%B6%E4%B8%8D%E5%8F%AF%E7%94%A8&status=503&redirect=%2Fbooklists&preview=1',
+    );
+
+    const cleanedParams = clearLoginErrorParams(params);
+
+    expect(cleanedParams.get('error')).toBeNull();
+    expect(cleanedParams.get('status')).toBeNull();
+    expect(cleanedParams.get('redirect')).toBe('/booklists');
+    expect(cleanedParams.get('preview')).toBe('1');
+    expect(params.get('error')).toBe('Discord暂时不可用');
+  });
+});

--- a/src/pages/AuthPage/loginError.ts
+++ b/src/pages/AuthPage/loginError.ts
@@ -1,0 +1,17 @@
+const MAX_LOGIN_ERROR_LENGTH = 240;
+
+export function normalizeLoginError(rawError: string | null): string | null {
+  if (rawError === null) return null;
+
+  const normalized = rawError.replace(/\s+/g, ' ').trim();
+  if (!normalized) return null;
+
+  return normalized.slice(0, MAX_LOGIN_ERROR_LENGTH);
+}
+
+export function clearLoginErrorParams(searchParams: URLSearchParams): URLSearchParams {
+  const cleanedParams = new URLSearchParams(searchParams);
+  cleanedParams.delete('error');
+  cleanedParams.delete('status');
+  return cleanedParams;
+}

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -44,6 +44,7 @@ import { scrollPageToTop } from "@/shared/lib/pageScroll";
 import { LayoutModeToggle } from "@/shared/ui/LayoutModeToggle";
 import {
   ArrowUpDown,
+  Clock3,
   MoveDown,
   MoveUp,
   Search,
@@ -60,11 +61,51 @@ const searchSortOptions = [
   { value: "relevance", label: "相关度" },
 ];
 
+function SearchRateLimitNotice({
+  remaining,
+  compact = false,
+}: {
+  remaining: number | null;
+  compact?: boolean;
+}) {
+  const message =
+    remaining === null
+      ? "搜索有点频繁，请稍后再试。"
+      : `搜索有点频繁，请在 ${remaining} 秒后再试。`;
+
+  if (compact) {
+    return (
+      <div
+        className="flex items-center gap-3 rounded-2xl border border-amber-400/25 bg-amber-400/8 px-4 py-3 text-sm text-(--od-text-secondary)"
+        role="status"
+      >
+        <Clock3 className="h-4 w-4 shrink-0 text-amber-500" />
+        <span>{message}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center py-20 text-center"
+      role="status"
+    >
+      <div className="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-amber-500/10 text-amber-500">
+        <Clock3 className="h-10 w-10" />
+      </div>
+      <h3 className="mb-2 text-xl font-bold text-(--od-text-primary)">
+        搜索有点频繁
+      </h3>
+      <p className="text-(--od-text-secondary)">{message}</p>
+    </div>
+  );
+}
+
 export function SearchPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { params, setParams } = useSearchURLParams();
-  const { query, channel: selectedChannel } = params;
+  const { query, channel: selectedChannel, page: currentSearchPage } = params;
   const isThreadTab = params.type === "thread";
   const isTournamentTab = params.type === "tournament";
   const collectionKeywords = useMemo(
@@ -94,6 +135,8 @@ export function SearchPage() {
     isPreferenceActive,
     queryState: { isLoading, isError, refetch },
     infiniteQueryState,
+    loadedPageCount,
+    preparePageRequest,
     results,
     pageSize,
     pageByThreadId,
@@ -101,6 +144,7 @@ export function SearchPage() {
     reportViewedPage,
     setIgnoreDiscoveryPreferences,
     totalResults,
+    visibleRateLimit,
   } = useSearchResults({ params, preferences });
 
   const animateIn = useListEntranceAnimation(isLoading);
@@ -156,6 +200,16 @@ export function SearchPage() {
       window.clearInterval(interval);
     };
   }, [location.pathname, location.search]);
+
+  useEffect(() => {
+    if (
+      !visibleRateLimit ||
+      loadedPageCount === 0 ||
+      currentSearchPage <= loadedPageCount
+    )
+      return;
+    setParams({ page: loadedPageCount });
+  }, [currentSearchPage, loadedPageCount, setParams, visibleRateLimit]);
 
   // 这些回调会传给 memo 化的 ThreadResultsCollection / ThreadCard，
   // 必须保持引用稳定，否则任何一次页面重渲染都会击穿整个列表的 memo。
@@ -476,26 +530,36 @@ export function SearchPage() {
                 ),
               )}
             </div>
-          ) : isError ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <div className="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-red-500/10 text-red-500">
-                <SlidersHorizontal className="h-10 w-10" />
+          ) : isError && !infiniteQueryState.data ? (
+            visibleRateLimit ? (
+              <SearchRateLimitNotice remaining={visibleRateLimit.remaining} />
+            ) : (
+              <div className="flex flex-col items-center justify-center py-20 text-center">
+                <div className="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-red-500/10 text-red-500">
+                  <SlidersHorizontal className="h-10 w-10" />
+                </div>
+                <h3 className="mb-2 text-xl font-bold text-(--od-text-primary)">
+                  搜索出错了
+                </h3>
+                <p className="mb-6 text-(--od-text-secondary)">
+                  暂时拉不到结果，稍后再试试吧。
+                </p>
+                <button
+                  onClick={() => refetch()}
+                  className="od-inline-action od-inline-action-primary px-6 py-3 text-sm"
+                >
+                  重试搜索
+                </button>
               </div>
-              <h3 className="mb-2 text-xl font-bold text-(--od-text-primary)">
-                搜索出错了
-              </h3>
-              <p className="mb-6 text-(--od-text-secondary)">
-                暂时拉不到结果，稍后再试试吧。
-              </p>
-              <button
-                onClick={() => refetch()}
-                className="od-inline-action od-inline-action-primary px-6 py-3 text-sm"
-              >
-                重试搜索
-              </button>
-            </div>
+            )
           ) : results.length > 0 ? (
             <div className="flex flex-col gap-6">
+              {visibleRateLimit && (
+                <SearchRateLimitNotice
+                  remaining={visibleRateLimit.remaining}
+                  compact
+                />
+              )}
               <ThreadResultsCollection
                 threads={results}
                 onTagClick={handleTagClick}
@@ -526,7 +590,9 @@ export function SearchPage() {
                   currentPage={params.page}
                   totalPages={searchTotalPages}
                   totalItems={totalResults}
-                  onChange={(page) => setParams({ page })}
+                  onChange={(page) => {
+                    if (preparePageRequest(page)) setParams({ page });
+                  }}
                   sequential
                 />
               )}

--- a/src/shared/api/rateLimit.test.ts
+++ b/src/shared/api/rateLimit.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getActiveRateLimit,
+  getRateLimitInfo,
+  parseRetryAfter,
+  RateLimitError,
+  rememberRateLimit,
+  resetRateLimitStateForTests,
+  shouldRetryQuery,
+} from "./rateLimit";
+
+function axios429(retryAfter?: string, url = "/search/") {
+  return {
+    isAxiosError: true,
+    config: { url },
+    response: {
+      status: 429,
+      headers: retryAfter === undefined ? {} : { "retry-after": retryAfter },
+    },
+  };
+}
+
+describe("rateLimit", () => {
+  beforeEach(() => resetRateLimitStateForTests());
+
+  it("解析秒数和 HTTP 日期格式的 Retry-After", () => {
+    const now = Date.parse("2026-08-15T00:00:00Z");
+    expect(parseRetryAfter("5", now)).toBe(5);
+    expect(parseRetryAfter("Sat, 15 Aug 2026 00:00:07 GMT", now)).toBe(7);
+  });
+
+  it("缺少 Retry-After 时不虚构冷却时间", () => {
+    const info = getRateLimitInfo(axios429(), { origin: "preload" });
+    expect(info).toMatchObject({
+      scope: "search",
+      origin: "preload",
+      retryAfterSeconds: null,
+      retryAt: null,
+    });
+  });
+
+  it("记录搜索冷却时间并在到期后自动清除", () => {
+    const now = 10_000;
+    rememberRateLimit({
+      scope: "search",
+      origin: "preload",
+      retryAfterSeconds: 5,
+      retryAt: now + 5_000,
+    });
+
+    expect(
+      getActiveRateLimit("search", "foreground", now + 2_000),
+    ).toMatchObject({
+      origin: "foreground",
+      retryAfterSeconds: 3,
+    });
+    expect(getActiveRateLimit("search", "foreground", now + 5_000)).toBeNull();
+  });
+
+  it("429 不重试，普通错误仍保留一次重试", () => {
+    const rateLimit = new RateLimitError({
+      scope: "search",
+      origin: "foreground",
+      retryAfterSeconds: 5,
+      retryAt: Date.now() + 5_000,
+    });
+
+    expect(shouldRetryQuery(0, rateLimit)).toBe(false);
+    expect(shouldRetryQuery(0, new Error("network"))).toBe(true);
+    expect(shouldRetryQuery(1, new Error("network"))).toBe(false);
+  });
+});

--- a/src/shared/api/rateLimit.ts
+++ b/src/shared/api/rateLimit.ts
@@ -1,0 +1,125 @@
+import axios from "axios";
+
+export type RateLimitScope = "search" | "global";
+export type RateLimitOrigin = "foreground" | "preload";
+
+export interface RateLimitInfo {
+  scope: RateLimitScope;
+  origin: RateLimitOrigin;
+  retryAfterSeconds: number | null;
+  retryAt: number | null;
+}
+
+const cooldowns = new Map<RateLimitScope, number>();
+
+export class RateLimitError extends Error {
+  readonly rateLimit: RateLimitInfo;
+  readonly originalError: unknown;
+
+  constructor(rateLimit: RateLimitInfo, originalError?: unknown) {
+    super("Request rate limited");
+    this.name = "RateLimitError";
+    this.rateLimit = rateLimit;
+    this.originalError = originalError;
+  }
+}
+
+export function parseRetryAfter(
+  value: unknown,
+  now = Date.now(),
+): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.ceil(value));
+  }
+
+  if (typeof value !== "string" || !value.trim()) return null;
+
+  const normalized = value.trim();
+  const seconds = Number(normalized);
+  if (Number.isFinite(seconds)) return Math.max(0, Math.ceil(seconds));
+
+  const retryAt = Date.parse(normalized);
+  if (Number.isNaN(retryAt)) return null;
+  return Math.max(0, Math.ceil((retryAt - now) / 1000));
+}
+
+export function getRateLimitInfo(
+  error: unknown,
+  defaults: Partial<Pick<RateLimitInfo, "scope" | "origin">> = {},
+  now = Date.now(),
+): RateLimitInfo | null {
+  if (error instanceof RateLimitError) {
+    return {
+      ...error.rateLimit,
+      retryAfterSeconds: getRemainingRateLimitSeconds(error.rateLimit, now),
+    };
+  }
+
+  if (!axios.isAxiosError(error) || error.response?.status !== 429) return null;
+
+  const headers = error.response.headers;
+  const retryAfter = headers?.["retry-after"] ?? headers?.["Retry-After"];
+  const retryAfterSeconds = parseRetryAfter(retryAfter, now);
+  const requestUrl = String(error.config?.url || "");
+  const scope =
+    defaults.scope || (requestUrl.includes("/search") ? "search" : "global");
+
+  return {
+    scope,
+    origin: defaults.origin || "foreground",
+    retryAfterSeconds,
+    retryAt: retryAfterSeconds === null ? null : now + retryAfterSeconds * 1000,
+  };
+}
+
+export function rememberRateLimit(info: RateLimitInfo): RateLimitInfo {
+  if (info.retryAt !== null) {
+    const current = cooldowns.get(info.scope) || 0;
+    cooldowns.set(info.scope, Math.max(current, info.retryAt));
+  }
+  return info;
+}
+
+export function getActiveRateLimit(
+  scope: RateLimitScope,
+  origin: RateLimitOrigin = "foreground",
+  now = Date.now(),
+): RateLimitInfo | null {
+  const retryAt = cooldowns.get(scope);
+  if (!retryAt) return null;
+  if (retryAt <= now) {
+    cooldowns.delete(scope);
+    return null;
+  }
+
+  return {
+    scope,
+    origin,
+    retryAt,
+    retryAfterSeconds: Math.max(1, Math.ceil((retryAt - now) / 1000)),
+  };
+}
+
+export function getRemainingRateLimitSeconds(
+  info: Pick<RateLimitInfo, "retryAt" | "retryAfterSeconds">,
+  now = Date.now(),
+): number | null {
+  if (info.retryAt === null) return info.retryAfterSeconds;
+  return Math.max(0, Math.ceil((info.retryAt - now) / 1000));
+}
+
+export function isSilentPreloadRateLimit(error: unknown): boolean {
+  return getRateLimitInfo(error)?.origin === "preload";
+}
+
+export function shouldRetryQuery(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (getRateLimitInfo(error)) return false;
+  return failureCount < 1;
+}
+
+export function resetRateLimitStateForTests() {
+  cooldowns.clear();
+}

--- a/src/shared/lib/notify.ts
+++ b/src/shared/lib/notify.ts
@@ -1,5 +1,10 @@
 import axios from 'axios';
 import { showMascotToast, type MascotToastOptions } from '@/features/mascot/lib/mascotToast';
+import {
+  getRateLimitInfo,
+  getRemainingRateLimitSeconds,
+  type RateLimitInfo,
+} from '@/shared/api/rateLimit';
 
 interface NotifyMessageOptions extends MascotToastOptions {
   description?: string;
@@ -29,8 +34,29 @@ export function notifyError(message: string, options?: NotifyMessageOptions) {
   });
 }
 
+export function formatRateLimitMessage(info: RateLimitInfo, now = Date.now()) {
+  const remaining = getRemainingRateLimitSeconds(info, now);
+  const subject = info.scope === 'search' ? '搜索' : '操作';
+  return remaining === null
+    ? `${subject}有点频繁，请稍后再试。`
+    : `${subject}有点频繁，请在 ${remaining} 秒后再试。`;
+}
+
+export function notifyRateLimit(info: RateLimitInfo) {
+  return showMascotToast({
+    id: `${info.scope}-rate-limit`,
+    emotion: 'complaint',
+    eyebrow: 'Rate Limit',
+    title: '操作有点频繁',
+    message: formatRateLimitMessage(info),
+    duration: 6000,
+  });
+}
+
 export function extractErrorMessage(error: unknown, fallback = '操作未完成，请稍后再试') {
   if (axios.isAxiosError(error)) {
+    const rateLimit = getRateLimitInfo(error);
+    if (rateLimit) return formatRateLimitMessage(rateLimit);
     const responseMessage =
       error.response?.data?.message ||
       error.response?.data?.detail ||


### PR DESCRIPTION
1. 后台预加载触发 429 时静默暂停，保留已有结果。
- 用户翻页、滚动加载或重新搜索时：
    - 限流未结束：不请求后端，顶部单例提示，并在结果区显示倒计时。
    - 限流已结束：正常重新请求，成功后恢复预加载。
- 首批搜索 429 会立即提示。
2. 登录失败时，根据后端返回的错误信息弹出提示